### PR TITLE
API, Performance and Docu improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Go Blob ![Build Status](https://github.com/mokiat/gblob/workflows/Go/badge.svg) [![Go Report Card](https://goreportcard.com/badge/github.com/mokiat/gblob)](https://goreportcard.com/report/github.com/mokiat/gblob) [![GoDoc](https://godoc.org/github.com/mokiat/gblob?status.svg)](https://godoc.org/github.com/mokiat/gblob)
+# Go Blob
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/mokiat/gblob.svg)](https://pkg.go.dev/github.com/mokiat/gblob)
+![Build Status](https://github.com/mokiat/gblob/workflows/Go/badge.svg)
+[![Go Report Card](https://goreportcard.com/badge/github.com/mokiat/gblob)](https://goreportcard.com/report/github.com/mokiat/gblob)
 
 A package that provides utilities for writing and reading primitive types to and from byte sequences.
 
@@ -6,34 +10,26 @@ A package that provides utilities for writing and reading primitive types to and
 
 For a more complete documentation, check the [GoDocs](https://pkg.go.dev/github.com/mokiat/gblob).
 
-### Block
+### Block API
 
-The **Block** API allows one to place values of concrete primitive types at specific offsets inside a byte slice.
+The **Block** API allows one to place values of concrete primitive types at specific offsets inside a byte slice. It is up to the caller to ensure that the slice has the necessary size.
 
 **Example:**
 
 ```go
+offset := 4
 block := make(gblob.LittleEndianBlock, 32)
-block.SetFloat32(4, 3.5)
+block.SetFloat32(offset, 3.5)
+fmt.Println(block.Float32(offset))
 ```
 
-There are two implementations available - **LittleEndianBlock** and **BigEndianBlock**.
+This API is similar to Go's built-in `binary.ByteOrder`. The difference here is that the gblob API is slightly more compact, it has helper functions for more primitive types and allows one to pass an offset into the byte slice for better readability.
 
-Following is a benchmark comparison between `Block` and Go's `binary.ByteOrder` API.
+There are two implementations available - **LittleEndianBlock** and **BigEndianBlock**, depending on the desired byte order.
 
-| Approach | Time per Operation | Allocated Memory per Operation | Allocation Count per Operation |
-| -------- | ------------------ | ------------------------------ | ------------------- |
-| `Block` | 0.2327 ns/op | 0 B/op | 0 allocs/op |
-| `binary.ByteOrder` | 0.2281 ns/op | 0 B/op | 0 allocs/op |
+### TypedWriter / TypedReader API
 
-Both APIs provide similar performance.
-
-> As with any benchmark result, take it with a grain of salt and do your own measurements according to your own requirements.
-
-
-### TypedWriter
-
-The **TypedWriter** API allows one to write concrete primitive types to an `io.Writer`.
+The **TypedWriter** API allows one to write concrete primitive types to an `io.Writer`. No padding or alignment is added to the output.
 
 **Example:**
 
@@ -43,22 +39,7 @@ writer := gblob.NewLittleEndianWriter(&buffer)
 writer.WriteUint64(0x13743521FA954321)
 ```
 
-There are two implementations available - **NewLittleEndianWriter** and **NewBigEndianWriter**.
-
-Following is a benchmark comparison between `TypedWriter` and Go's `binary.Write` functions.
-
-| Approach | Time per Operation | Allocated Memory per Operation | Allocation Count per Operation |
-| -------- | ------------------ | ------------------------------ | ------------------- |
-| `TypedWriter` | 56.97 ns/op | 0 B/op | 0 allocs/op |
-| `binary.Write` | 175.5 ns/op | 32 B/op | 6 allocs/op |
-
-As can be seen, not only does the TypedWriter not allocate any memory, but it also runs about `3 times` faster.
-
-> As with any benchmark result, take it with a grain of salt and do your own measurements according to your own requirements.
-
-**NOTE:** In reality the `TypedWriter` does allocate around `8 bytes` but only when first created (uses it for a write buffer). It does not allocate during write operations.
-
-### TypedReader
+There are two implementations available - **NewLittleEndianWriter** and **NewBigEndianWriter**, depending on the desired byte order.
 
 The **TypedReader** API allows one to read concrete primitive types from an `io.Reader`.
 
@@ -72,22 +53,9 @@ reader := gblob.NewLittleEndianReader(buffer)
 value, err := reader.ReadUint64()
 ```
 
-There are two implementations available - **NewLittleEndianReader** and **NewBigEndianReader**.
+There are two implementations available - **NewLittleEndianReader** and **NewBigEndianReader**, depending on the desired byte order.
 
-Following is a benchmark comparison between `TypedReader` and Go's `binary.Read` functions.
-
-| Approach | Time per Operation | Allocated Memory per Operation | Allocation Count per Operation |
-| -------- | ------------------ | ------------------------------ | ------------------- |
-| `TypedReader` | 61.69 ns/op | 0 B/op | 0 allocs/op |
-| `binary.Read` | 226.3 ns/op | 56 B/op | 12 allocs/op |
-
-As can be seen, not only does the TypedReader not allocate any memory, but it also runs nearly `4 times` faster.
-
-> As with any benchmark result, take it with a grain of salt and do your own measurements according to your own requirements.
-
-**NOTE:** In reality the `TypedReader` does allocate around `8 bytes` but only when first created (uses it for a read buffer). It does not allocate during read operations.
-
-### PackedEncoder
+### PackedEncoder / PackedDecoder API
 
 The **PackedEncoder** API allows one to marshal a data structure to a binary
 sequence.
@@ -105,33 +73,9 @@ gblob.NewLittleEndianPackedEncoder(&buffer).Encode(struct{
 })
 ```
 
-There are two implementations available - **NewLittleEndianPackedEncoder** and **NewBigEndianPackedEncoder**.
+There are two implementations available - **NewLittleEndianPackedEncoder** and **NewBigEndianPackedEncoder**, depending on the desired byte order.
 
-It is difficult to compare the `PackedEncoder` API with `binary.Write` or `gob.NewEncoder`, since the former has less
-flexibility to the types it can read and the latter is much more flexible - it allows for forward compatible
-serialization.
-
-Nevertheless, following is a benchmark comparison between `PackedEncoder` and Go's `gob.NewEncoder` functions.
-
-| Approach | Time per Operation | Allocated Memory per Operation | Allocation Count per Operation |
-| -------- | ------------------ | ------------------------------ | ------------------- |
-| `PackedEncoder` | 242.6 ns/op | 72 B/op | 2 allocs/op |
-| `gob.NewEncoder` | 408.7 ns/op | 72 B/op | 2 allocs/op |
-
-The `PackedEncoder` is almost twice faster. Memory allocation is equal.
-
-And following is a benchmark comparison between `PackedEncoder` and Go's `binary.Write` functions.
-
-| Approach | Time per Operation | Allocated Memory per Operation | Allocation Count per Operation |
-| -------- | ------------------ | ------------------------------ | ------------------- |
-| `PackedEncoder` | 133.7 ns/op | 32 B/op | 1 allocs/op |
-| `binary.Write` | 442.9 ns/op | 112 B/op | 8 allocs/op |
-
-The `PackedEncoder` is significantly quicker and it allocates less memory.
-
-> As with any benchmark result, take it with a grain of salt and do your own measurements according to your own requirements.
-
-### PackedDecoder
+This is similar to Go's `bytes.Write`, except that it supports slices, maps and strings.
 
 The **PackedDecoder** API allows one to unmarshal a data structure from a
 binary sequence that was previously marshaled through the PackedEncoder API.
@@ -146,30 +90,91 @@ var target uint64
 gblob.NewLittleEndianPackedDecoder(buffer).Decode(&target)
 ```
 
-There are two implementations available - **NewLittleEndianPackedDecoder** and **NewBigEndianPackedDecoder**.
+There are two implementations available - **NewLittleEndianPackedDecoder** and **NewBigEndianPackedDecoder**, depending on the desired byte order.
 
-It is difficult to compare the `PackedDecoder` API with `binary.Read` or `gob.NewDecoder`, since the former has less
-flexibility to the types it can read and the latter is much more flexible - it allows for backward compatible
-deserialization.
+This is similar to Go's `bytes.Read`, except that it supports slices, maps and strings.
 
-Nevertheless, following is a benchmark comparison between `PackedDecoder` and Go's `gob.NewDecoder` functions.
+## Performance
+
+Following are some benchmark results. They compare this library against Go's `binary` and `gob`, since those are closest in terms of features.
+
+Nevertheless, there is not a complete feature parity between the packages, hence the `glob` library is not a direct replacement nor are the test exhaustive.
+
+Take the results that follow with a grain of salt. Do your own measurements for your particular use case if you consider using the library.
+
+### Block API
+
+Following is a benchmark comparison between `Block` and Go's `binary.ByteOrder` API.
+
+| Approach | Time per Operation | Allocated Memory per Operation | Allocation Count per Operation |
+| -------- | ------------------ | ------------------------------ | ------------------- |
+| `Block` | 0.2327 ns/op | 0 B/op | 0 allocs/op |
+| `binary.ByteOrder` | 0.2281 ns/op | 0 B/op | 0 allocs/op |
+
+> Both APIs provide similar performance so it boils down to ease of use of and personal preference.
+
+### TypedWriter
+
+Following is a benchmark comparison between `TypedWriter` and Go's `binary.Write` functions.
+
+| Approach | Time per Operation | Allocated Memory per Operation | Allocation Count per Operation |
+| -------- | ------------------ | ------------------------------ | ------------------- |
+| `TypedWriter` | 56.97 ns/op | 0 B/op | 0 allocs/op |
+| `binary.Write` | 175.5 ns/op | 32 B/op | 6 allocs/op |
+
+> The `TypedWriter` does not allocate any memory per write operation and it also runs about `3 times` faster. In reality, it allocates an initial buffer of size `8 bytes` that it reuses to achieve thes results.
+
+### TypedReader
+
+Following is a benchmark comparison between `TypedReader` and Go's `binary.Read` functions.
+
+| Approach | Time per Operation | Allocated Memory per Operation | Allocation Count per Operation |
+| -------- | ------------------ | ------------------------------ | ------------------- |
+| `TypedReader` | 61.69 ns/op | 0 B/op | 0 allocs/op |
+| `binary.Read` | 226.3 ns/op | 56 B/op | 12 allocs/op |
+
+> The `TypedReader` does not allocate any memory per read and it also runs nearly `4 times` faster. This is again achieved by having the `TypedReader` allocate an initial buffer of `8 bytes` that it reuses.
+
+### PackedEncoder
+
+It is difficult to compare the `PackedEncoder` API with `binary.Write` or `gob.NewEncoder`, since the former has less flexibility to the types it can read and the latter is much more flexible - it allows for forward compatible serialization.
+
+Nevertheless, following is a benchmark comparison between `PackedEncoder` and Go's `gob.Encoder`.
+
+| Approach | Time per Operation | Allocated Memory per Operation | Allocation Count per Operation |
+| -------- | ------------------ | ------------------------------ | ------------------- |
+| `PackedEncoder` | 242.6 ns/op | 72 B/op | 2 allocs/op |
+| `gob.Encoder` | 408.7 ns/op | 72 B/op | 2 allocs/op |
+
+> `PackedEncoder` is almost twice faster. Memory allocation is equal.
+
+And following is a benchmark comparison between `PackedEncoder` and Go's `binary.Write` function.
+
+| Approach | Time per Operation | Allocated Memory per Operation | Allocation Count per Operation |
+| -------- | ------------------ | ------------------------------ | ------------------- |
+| `PackedEncoder` | 133.7 ns/op | 32 B/op | 1 allocs/op |
+| `binary.Write` | 442.9 ns/op | 112 B/op | 8 allocs/op |
+
+> The `PackedEncoder` is significantly quicker and it allocates less memory.
+
+### PackedDecoder
+
+It is difficult to compare the `PackedDecoder` API with `binary.Read` or `gob.Decoder`, since the former has less flexibility to the types it can read and the latter is much more flexible - it allows for backward compatible deserialization.
+
+Nevertheless, following is a benchmark comparison between `PackedDecoder` and Go's `gob.Decoder`.
 
 | Approach | Time per Operation | Allocated Memory per Operation | Allocation Count per Operation |
 | -------- | ------------------ | ------------------------------ | ------------------- |
 | `PackedDecoder` | 434.6 ns/op | 152 B/op | 5 allocs/op |
-| `gob.NewDecoder` | 19480 ns/op | 7928 B/op | 212 allocs/op |
+| `gob.Decoder` | 19480 ns/op | 7928 B/op | 212 allocs/op |
 
-As can be seen, the `PackedDecoder` is much faster and barely allocates memory. On the downside, a change to the target
-type would break decoding, which is not the case with `gob.NewDecoder`.
+> As can be seen, the `PackedDecoder` is much faster and barely allocates memory. On the downside, a change to the target type would break decoding, which is not the case with `gob.Decoder`.
 
-And following is a benchmark comparison between `PackedDecoder` and Go's `binary.Read` functions.
+And following is a benchmark comparison between `PackedDecoder` and Go's `binary.Read` function.
 
 | Approach | Time per Operation | Allocated Memory per Operation | Allocation Count per Operation |
 | -------- | ------------------ | ------------------------------ | ------------------- |
 | `PackedDecoder` | 187.7 ns/op | 32 B/op | 1 allocs/op |
 | `binary.Read` | 173.5 ns/op | 64 B/op | 2 allocs/op |
 
-The `PackedDecoder` is marginably slower, though it allocates slightly less memory and has the added benefit of
-supporing types like slice and map.
-
-> As with any benchmark result, take it with a grain of salt and do your own measurements according to your own requirements.
+> The `PackedDecoder` is marginably slower, though it allocates slightly less memory and has the added benefit of supporing types like slice and map.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@
 
 A package that provides utilities for writing and reading primitive types to and from byte sequences.
 
+
 ## User's Guide
 
 For a more complete documentation, check the [GoDocs](https://pkg.go.dev/github.com/mokiat/gblob).
+
 
 ### Block API
 
@@ -26,6 +28,7 @@ fmt.Println(block.Float32(offset))
 This API is similar to Go's built-in `binary.ByteOrder`. The difference here is that the gblob API is slightly more compact, it has helper functions for more primitive types and allows one to pass an offset into the byte slice for better readability.
 
 There are two implementations available - **LittleEndianBlock** and **BigEndianBlock**, depending on the desired byte order.
+
 
 ### TypedWriter / TypedReader API
 
@@ -54,6 +57,7 @@ value, err := reader.ReadUint64()
 ```
 
 There are two implementations available - **NewLittleEndianReader** and **NewBigEndianReader**, depending on the desired byte order.
+
 
 ### PackedEncoder / PackedDecoder API
 
@@ -94,87 +98,87 @@ There are two implementations available - **NewLittleEndianPackedDecoder** and *
 
 This is similar to Go's `bytes.Read`, except that it supports slices, maps and strings.
 
+
 ## Performance
 
-Following are some benchmark results. They compare this library against Go's `binary` and `gob`, since those are closest in terms of features.
+Following are some benchmark results. They compare this library against Go's `binary` and `gob` packages, since those are closest in terms of features. Results are based on the following hardware:
 
-Nevertheless, there is not a complete feature parity between the packages, hence the `glob` library is not a direct replacement nor are the test exhaustive.
+```
+goos: linux
+goarch: amd64
+pkg: github.com/mokiat/gblob
+cpu: AMD Ryzen 7 3700X 8-Core Processor
+```
 
-Take the results that follow with a grain of salt. Do your own measurements for your particular use case if you consider using the library.
+You can find the benchmark tests in the `bench_test.go` file. You can run them with the following command:
+
+```sh
+go test -benchmem -run=^$ -bench ^Benchmark github.com/mokiat/gblob
+```
+Adjust the `^Benchmark` regex to focus on specific benchmark sets and use the `-cpuprofile bench.pprof` flag if profiling is desired.
+
+Take the results that follow with a grain of salt. Do your own measurements for your particular use case.
+
 
 ### Block API
 
 Following is a benchmark comparison between `Block` and Go's `binary.ByteOrder` API.
 
 | Approach | Time per Operation | Allocated Memory per Operation | Allocation Count per Operation |
-| -------- | ------------------ | ------------------------------ | ------------------- |
-| `Block` | 0.2327 ns/op | 0 B/op | 0 allocs/op |
-| `binary.ByteOrder` | 0.2281 ns/op | 0 B/op | 0 allocs/op |
+| -------- | -----------------: | -----------------------------: | ------------------: |
+| `Block` | 1493 ns/op | 0 B/op | 0 allocs/op |
+| `binary.ByteOrder` | 1496 ns/op | 0 B/op | 0 allocs/op |
 
 > Both APIs provide similar performance so it boils down to ease of use of and personal preference.
+
 
 ### TypedWriter
 
 Following is a benchmark comparison between `TypedWriter` and Go's `binary.Write` functions.
 
 | Approach | Time per Operation | Allocated Memory per Operation | Allocation Count per Operation |
-| -------- | ------------------ | ------------------------------ | ------------------- |
-| `TypedWriter` | 56.97 ns/op | 0 B/op | 0 allocs/op |
-| `binary.Write` | 175.5 ns/op | 32 B/op | 6 allocs/op |
+| -------- | -----------------: | -----------------------------: | ------------------: |
+| `TypedWriter` | 7753 ns/op | 0 B/op | 0 allocs/op |
+| `binary.Write` | 39768 ns/op | 4096 B/op | 1024 allocs/op |
 
-> The `TypedWriter` does not allocate any memory per write operation and it also runs about `3 times` faster. In reality, it allocates an initial buffer of size `8 bytes` that it reuses to achieve thes results.
+> The `TypedWriter` does not allocate any memory per write operation and it also runs about `3-4 times` faster. In reality, it allocates an initial buffer of size `8 bytes` that it reuses to achieve these results.
+
 
 ### TypedReader
 
 Following is a benchmark comparison between `TypedReader` and Go's `binary.Read` functions.
 
 | Approach | Time per Operation | Allocated Memory per Operation | Allocation Count per Operation |
-| -------- | ------------------ | ------------------------------ | ------------------- |
-| `TypedReader` | 61.69 ns/op | 0 B/op | 0 allocs/op |
-| `binary.Read` | 226.3 ns/op | 56 B/op | 12 allocs/op |
+| -------- | -----------------: | -----------------------------: | ------------------: |
+| `TypedReader` | 11595 ns/op | 0 B/op | 0 allocs/op |
+| `binary.Read` | 53088 ns/op | 4096 B/op | 1024 allocs/op |
 
-> The `TypedReader` does not allocate any memory per read and it also runs nearly `4 times` faster. This is again achieved by having the `TypedReader` allocate an initial buffer of `8 bytes` that it reuses.
+> The `TypedReader` does not allocate any memory per read and it also runs `4-5 times` faster. This is again achieved by having the `TypedReader` allocate an initial buffer of `8 bytes` that it reuses.
+
 
 ### PackedEncoder
 
-It is difficult to compare the `PackedEncoder` API with `binary.Write` or `gob.NewEncoder`, since the former has less flexibility to the types it can read and the latter is much more flexible - it allows for forward compatible serialization.
+When serializing larger types with `PackedEncoder` vs `binary.Write`, the performance difference is negligible, though the memory aspect remains the same as before. More interesting in this case is the comparison with `gob.Encoder`, due to a similar feature set.
 
-Nevertheless, following is a benchmark comparison between `PackedEncoder` and Go's `gob.Encoder`.
-
-| Approach | Time per Operation | Allocated Memory per Operation | Allocation Count per Operation |
-| -------- | ------------------ | ------------------------------ | ------------------- |
-| `PackedEncoder` | 242.6 ns/op | 72 B/op | 2 allocs/op |
-| `gob.Encoder` | 408.7 ns/op | 72 B/op | 2 allocs/op |
-
-> `PackedEncoder` is almost twice faster. Memory allocation is equal.
-
-And following is a benchmark comparison between `PackedEncoder` and Go's `binary.Write` function.
+**WARNING:** The scenario that is compared is the one where a new instance of an `Encoder` is created for each `Encode` performed (i.e. `gob.NewEncoder(out).Encode(&target)`). This is arguably the more common scenario (saving an asset / writing a response). When a `gob.Encoder` is reused to encode multiple sequences of items to a stream, it is significantly faster than `PackedEncoder`, likely due to caching.
 
 | Approach | Time per Operation | Allocated Memory per Operation | Allocation Count per Operation |
-| -------- | ------------------ | ------------------------------ | ------------------- |
-| `PackedEncoder` | 133.7 ns/op | 32 B/op | 1 allocs/op |
-| `binary.Write` | 442.9 ns/op | 112 B/op | 8 allocs/op |
+| -------- | -----------------: | -----------------------------: | ------------------: |
+| `PackedEncoder` | 7644113 ns/op | 179158 B/op | 3072 allocs/op |
+| `gob.Encoder` | 11349161 ns/op | 2408841 B/op | 38912 allocs/op |
 
-> The `PackedEncoder` is significantly quicker and it allocates less memory.
+> Here the `gob.Encoder` performs worse, especially when memory is concerned.
+
 
 ### PackedDecoder
 
-It is difficult to compare the `PackedDecoder` API with `binary.Read` or `gob.Decoder`, since the former has less flexibility to the types it can read and the latter is much more flexible - it allows for backward compatible deserialization.
+Following is the comparison between `PackedDecoder` and `gob.Decoder`.
 
-Nevertheless, following is a benchmark comparison between `PackedDecoder` and Go's `gob.Decoder`.
-
-| Approach | Time per Operation | Allocated Memory per Operation | Allocation Count per Operation |
-| -------- | ------------------ | ------------------------------ | ------------------- |
-| `PackedDecoder` | 434.6 ns/op | 152 B/op | 5 allocs/op |
-| `gob.Decoder` | 19480 ns/op | 7928 B/op | 212 allocs/op |
-
-> As can be seen, the `PackedDecoder` is much faster and barely allocates memory. On the downside, a change to the target type would break decoding, which is not the case with `gob.Decoder`.
-
-And following is a benchmark comparison between `PackedDecoder` and Go's `binary.Read` function.
+**WARNING:** The scenario that is compared is the one where a new instance of a `Decoder` is created for each `Decode` performed (i.e. `gob.NewDecoder(in).Decode(&target)`). This is arguably the more common scenario (loading an asset / reading a request). When a `gob.Decoder` is reused to read multiple sequences of items from a stream, it is significantly faster than `PackedDecoder`, likely due to caching.
 
 | Approach | Time per Operation | Allocated Memory per Operation | Allocation Count per Operation |
-| -------- | ------------------ | ------------------------------ | ------------------- |
-| `PackedDecoder` | 187.7 ns/op | 32 B/op | 1 allocs/op |
-| `binary.Read` | 173.5 ns/op | 64 B/op | 2 allocs/op |
+| -------- | -----------------: | -----------------------------: | ------------------: |
+| `PackedDecoder` | 17483112 ns/op | 2261422 B/op | 5120 allocs/op |
+| `gob.Decoder` | 45206563 ns/op | 11466272 B/op | 236565 allocs/op |
 
-> The `PackedDecoder` is marginably slower, though it allocates slightly less memory and has the added benefit of supporing types like slice and map.
+> The `gob.Decoder` performs werse, especially when memory is concerned.

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,373 @@
+package gblob_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/gob"
+	"testing"
+
+	"github.com/mokiat/gblob"
+)
+
+//
+// Block API comparison follows.
+//
+
+func Benchmark_BlockAPI_Block(b *testing.B) {
+	const (
+		itemCount   = 1024
+		expectedSum = itemCount * (0 + itemCount - 1) / 2
+	)
+
+	data := make(gblob.LittleEndianBlock, itemCount*4)
+
+	b.ResetTimer()
+
+	for range b.N {
+		for i := range itemCount {
+			data.SetUint32(i*4, uint32(i))
+		}
+		sum := uint32(0)
+		for i := range itemCount {
+			value := data.Uint32(i * 4)
+			sum += value
+		}
+		if sum != expectedSum {
+			b.Errorf("Sum %d is not equal to %d", sum, expectedSum)
+		}
+	}
+}
+
+func Benchmark_BlockAPI_ByteOrder(b *testing.B) {
+	const (
+		itemCount   = 1024
+		expectedSum = itemCount * (0 + itemCount - 1) / 2
+	)
+
+	data := make([]byte, itemCount*4)
+
+	b.ResetTimer()
+
+	for range b.N {
+		for i := range itemCount {
+			binary.LittleEndian.PutUint32(data[i*4:], uint32(i))
+		}
+		sum := uint32(0)
+		for i := range itemCount {
+			value := binary.LittleEndian.Uint32(data[i*4:])
+			sum += value
+		}
+		if sum != expectedSum {
+			b.Errorf("Sum %d is not equal to %d", sum, expectedSum)
+		}
+	}
+}
+
+//
+// Writer API comparison follows.
+//
+
+func Benchmark_Writer_TypedWriter(b *testing.B) {
+	const itemCount = 1024
+
+	data := bytes.NewBuffer(make([]byte, itemCount*4))
+
+	writer := gblob.NewLittleEndianWriter(data)
+
+	b.ResetTimer()
+
+	for range b.N {
+		data.Reset()
+		for i := range itemCount {
+			writer.WriteUint32(uint32(i))
+		}
+		if data.Len() != itemCount*4 {
+			b.Errorf("Length %d is not equal to %d", data.Len(), itemCount)
+		}
+	}
+}
+
+func Benchmark_Writer_BinaryWrite(b *testing.B) {
+	const itemCount = 1024
+
+	data := bytes.NewBuffer(make([]byte, itemCount*4))
+
+	b.ResetTimer()
+
+	for range b.N {
+		data.Reset()
+		for i := range itemCount {
+			binary.Write(data, binary.LittleEndian, uint32(i))
+		}
+		if data.Len() != itemCount*4 {
+			b.Errorf("Length %d is not equal to %d", data.Len(), itemCount)
+		}
+	}
+}
+
+//
+// Reader API comparison follows.
+//
+
+func Benchmark_Reader_TypedReader(b *testing.B) {
+	const itemCount = 1024
+
+	data := make([]byte, itemCount*4)
+	for i := range data {
+		data[i] = (byte(i % 256))
+	}
+	seeker := bytes.NewReader(data)
+
+	reader := gblob.NewLittleEndianReader(seeker)
+
+	b.ResetTimer()
+
+	for range b.N {
+		seeker.Reset(data)
+		sum := uint32(0)
+		for range itemCount {
+			val, _ := reader.ReadUint32()
+			sum += val
+		}
+		if sum <= 0 {
+			b.Errorf("Sum %d is not positive", sum)
+		}
+	}
+}
+
+func Benchmark_Reader_BinaryRead(b *testing.B) {
+	const itemCount = 1024
+
+	data := make([]byte, itemCount*4)
+	for i := range data {
+		data[i] = (byte(i % 256))
+	}
+	seeker := bytes.NewReader(data)
+
+	b.ResetTimer()
+
+	for range b.N {
+		seeker.Reset(data)
+		sum := uint32(0)
+		for range itemCount {
+			var val uint32
+			binary.Read(seeker, binary.LittleEndian, &val)
+			sum += val
+		}
+		if sum <= 0 {
+			b.Errorf("Sum %d is not positive", sum)
+		}
+	}
+}
+
+//
+// Encode API comparison follows.
+//
+
+func Benchmark_Encoder_PackedEncoder(b *testing.B) {
+	const itemCount = 1024
+
+	type encodeStruct struct {
+		A uint32
+		B int16
+		C float64
+		D float32
+		E [32]byte
+		F struct {
+			G byte
+		}
+		H []uint64
+	}
+	template := encodeStruct{
+		A: 0,
+		B: 10,
+		C: 32.0,
+		D: 100.0,
+		E: [32]byte{
+			0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+			0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+		},
+		F: struct{ G byte }{
+			G: 255,
+		},
+		H: make([]uint64, 256),
+	}
+
+	data := bytes.NewBuffer(make([]byte, 0, itemCount*1024))
+
+	b.ResetTimer()
+
+	for range b.N {
+		data.Reset()
+
+		for range itemCount {
+			if err := gblob.NewLittleEndianPackedEncoder(data).Encode(template); err != nil {
+				panic(err)
+			}
+		}
+		if len := data.Len(); len <= 0 {
+			b.Errorf("Length %d is not positive", data.Len())
+		}
+	}
+}
+
+func Benchmark_Encoder_GobEncoder(b *testing.B) {
+	const itemCount = 1024
+
+	type encodeStruct struct {
+		A uint32
+		B int16
+		C float64
+		D float32
+		E [32]byte
+		F struct {
+			G byte
+		}
+		H []uint64
+	}
+	template := encodeStruct{
+		A: 0,
+		B: 10,
+		C: 32.0,
+		D: 100.0,
+		E: [32]byte{
+			0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+			0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+		},
+		F: struct{ G byte }{
+			G: 255,
+		},
+		H: make([]uint64, 256),
+	}
+
+	data := bytes.NewBuffer(make([]byte, 0, itemCount*1024))
+
+	b.ResetTimer()
+
+	for range b.N {
+		data.Reset()
+
+		for range itemCount {
+			if err := gob.NewEncoder(data).Encode(template); err != nil {
+				panic(err)
+			}
+		}
+		if len := data.Len(); len <= 0 {
+			b.Errorf("Length %d is not positive", data.Len())
+		}
+	}
+}
+
+//
+// Decode API comparison follows.
+//
+
+func Benchmark_Decoder_PackedDecoder(b *testing.B) {
+	const itemCount = 1024
+
+	type encodeStruct struct {
+		A uint32
+		B int16
+		C float64
+		D float32
+		E [32]byte
+		F struct {
+			G byte
+		}
+		H []uint64
+	}
+
+	data := bytes.NewBuffer(make([]byte, 0, itemCount*1024))
+	template := encodeStruct{
+		A: 0,
+		B: 10,
+		C: 32.0,
+		D: 100.0,
+		E: [32]byte{
+			0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+			0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+		},
+		F: struct{ G byte }{
+			G: 255,
+		},
+		H: make([]uint64, 256),
+	}
+	for range itemCount {
+		if err := gblob.NewLittleEndianPackedEncoder(data).Encode(template); err != nil {
+			panic(err)
+		}
+	}
+
+	seeker := bytes.NewReader(data.Bytes())
+
+	b.ResetTimer()
+
+	for range b.N {
+		seeker.Reset(data.Bytes())
+
+		for range itemCount {
+			var template encodeStruct
+			if err := gblob.NewLittleEndianPackedDecoder(seeker).Decode(&template); err != nil {
+				panic(err)
+			}
+			if template.B != 10 {
+				b.Errorf("Field B %d is not equal to 10", template.B)
+			}
+		}
+	}
+}
+
+func Benchmark_Decoder_GobDecoder(b *testing.B) {
+	const itemCount = 1024
+
+	type encodeStruct struct {
+		A uint32
+		B int16
+		C float64
+		D float32
+		E [32]byte
+		F struct {
+			G byte
+		}
+		H []uint64
+	}
+
+	data := bytes.NewBuffer(make([]byte, 0, itemCount*1024))
+	template := encodeStruct{
+		A: 0,
+		B: 10,
+		C: 32.0,
+		D: 100.0,
+		E: [32]byte{
+			0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+			0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+		},
+		F: struct{ G byte }{
+			G: 255,
+		},
+		H: make([]uint64, 256),
+	}
+	for range itemCount {
+		if err := gob.NewEncoder(data).Encode(template); err != nil {
+			panic(err)
+		}
+	}
+
+	seeker := bytes.NewReader(data.Bytes())
+
+	b.ResetTimer()
+
+	for range b.N {
+		seeker.Reset(data.Bytes())
+
+		for range itemCount {
+			var template encodeStruct
+			if err := gob.NewDecoder(seeker).Decode(&template); err != nil {
+				panic(err)
+			}
+			if template.B != 10 {
+				b.Errorf("Field B %d is not equal to 10", template.B)
+			}
+		}
+	}
+}

--- a/block.go
+++ b/block.go
@@ -96,6 +96,7 @@ func (b LittleEndianBlock) SetInt8(offset int, value int8) {
 // Uint16 returns the uint16 value at the specified offset.
 func (b LittleEndianBlock) Uint16(offset int) uint16 {
 	b = b[offset:] // runs faster this way
+	_ = b[1]       // early bounds check
 	return uint16(b[0])<<0 |
 		uint16(b[1])<<8
 }
@@ -103,6 +104,7 @@ func (b LittleEndianBlock) Uint16(offset int) uint16 {
 // SetUint16 places the uint16 value at the specified offset.
 func (b LittleEndianBlock) SetUint16(offset int, value uint16) {
 	b = b[offset:] // runs faster this way
+	_ = b[1]       // early bounds check
 	b[0] = byte(value >> 0)
 	b[1] = byte(value >> 8)
 }
@@ -120,6 +122,7 @@ func (b LittleEndianBlock) SetInt16(offset int, value int16) {
 // Uint32 returns the uint32 value at the specified offset.
 func (b LittleEndianBlock) Uint32(offset int) uint32 {
 	b = b[offset:] // runs faster this way
+	_ = b[3]       // early bounds check
 	return uint32(b[0])<<0 |
 		uint32(b[1])<<8 |
 		uint32(b[2])<<16 |
@@ -129,6 +132,7 @@ func (b LittleEndianBlock) Uint32(offset int) uint32 {
 // SetUint32 places the uint32 value at the specified offset.
 func (b LittleEndianBlock) SetUint32(offset int, value uint32) {
 	b = b[offset:] // runs faster this way
+	_ = b[3]       // early bounds check
 	b[0] = byte(value >> 0)
 	b[1] = byte(value >> 8)
 	b[2] = byte(value >> 16)
@@ -148,6 +152,7 @@ func (b LittleEndianBlock) SetInt32(offset int, value int32) {
 // Uint64 returns the uint64 value at the specified offset.
 func (b LittleEndianBlock) Uint64(offset int) uint64 {
 	b = b[offset:] // runs faster this way
+	_ = b[7]       // early bounds check
 	return uint64(b[0])<<0 |
 		uint64(b[1])<<8 |
 		uint64(b[2])<<16 |
@@ -161,6 +166,7 @@ func (b LittleEndianBlock) Uint64(offset int) uint64 {
 // SetUint64 places the uint64 value at the specified offset.
 func (b LittleEndianBlock) SetUint64(offset int, value uint64) {
 	b = b[offset:] // runs faster this way
+	_ = b[7]       // early bounds check
 	b[0] = byte(value >> 0)
 	b[1] = byte(value >> 8)
 	b[2] = byte(value >> 16)
@@ -230,6 +236,7 @@ func (b BigEndianBlock) SetInt8(offset int, value int8) {
 // Uint16 returns the uint16 value at the specified offset.
 func (b BigEndianBlock) Uint16(offset int) uint16 {
 	b = b[offset:] // runs faster this way
+	_ = b[1]       // early bounds check
 	return uint16(b[1])<<0 |
 		uint16(b[0])<<8
 }
@@ -237,6 +244,7 @@ func (b BigEndianBlock) Uint16(offset int) uint16 {
 // SetUint16 places the uint16 value at the specified offset.
 func (b BigEndianBlock) SetUint16(offset int, value uint16) {
 	b = b[offset:] // runs faster this way
+	_ = b[1]       // early bounds check
 	b[1] = byte(value >> 0)
 	b[0] = byte(value >> 8)
 }
@@ -254,6 +262,7 @@ func (b BigEndianBlock) SetInt16(offset int, value int16) {
 // Uint32 returns the uint32 value at the specified offset.
 func (b BigEndianBlock) Uint32(offset int) uint32 {
 	b = b[offset:] // runs faster this way
+	_ = b[3]       // early bounds check
 	return uint32(b[3])<<0 |
 		uint32(b[2])<<8 |
 		uint32(b[1])<<16 |
@@ -263,6 +272,7 @@ func (b BigEndianBlock) Uint32(offset int) uint32 {
 // SetUint32 places the uint32 value at the specified offset.
 func (b BigEndianBlock) SetUint32(offset int, value uint32) {
 	b = b[offset:] // runs faster this way
+	_ = b[3]       // early bounds check
 	b[3] = byte(value >> 0)
 	b[2] = byte(value >> 8)
 	b[1] = byte(value >> 16)
@@ -282,6 +292,7 @@ func (b BigEndianBlock) SetInt32(offset int, value int32) {
 // Uint64 returns the uint64 value at the specified offset.
 func (b BigEndianBlock) Uint64(offset int) uint64 {
 	b = b[offset:] // runs faster this way
+	_ = b[7]       // early bounds check
 	return uint64(b[7])<<0 |
 		uint64(b[6])<<8 |
 		uint64(b[5])<<16 |
@@ -295,6 +306,7 @@ func (b BigEndianBlock) Uint64(offset int) uint64 {
 // SetUint64 places the uint64 value at the specified offset.
 func (b BigEndianBlock) SetUint64(offset int, value uint64) {
 	b = b[offset:] // runs faster this way
+	_ = b[7]       // early bounds check
 	b[7] = byte(value >> 0)
 	b[6] = byte(value >> 8)
 	b[5] = byte(value >> 16)

--- a/packed_decoder_test.go
+++ b/packed_decoder_test.go
@@ -295,5 +295,34 @@ var _ = Describe("PackedDecoder", func() {
 				C: 0x01,
 			}),
 		),
+		Entry("Decodable",
+			seq(0x39),
+			&testDecodable{},
+			&testDecodable{
+				value: 0x39,
+			},
+		),
+		Entry("*Decodable",
+			seq(0x39),
+			gog.PtrOf((*testDecodable)(nil)),
+			gog.PtrOf(&testDecodable{
+				value: 0x39,
+			}),
+		),
 	)
 })
+
+type testDecodable struct {
+	value byte
+}
+
+var _ gblob.PackedDecodable = (*testDecodable)(nil)
+
+func (d *testDecodable) DecodePacked(reader gblob.TypedReader) error {
+	v, err := reader.ReadUint8()
+	if err != nil {
+		return err
+	}
+	d.value = v
+	return nil
+}

--- a/packed_encoder_test.go
+++ b/packed_encoder_test.go
@@ -273,5 +273,21 @@ var _ = Describe("PackedEncoder", func() {
 			}),
 			seq(0x66, 0x55, 0xFF, 0x01),
 		),
+		Entry("Encodable",
+			testEncodable{},
+			seq(0x39),
+		),
+		Entry("*Encodable",
+			&testEncodable{},
+			seq(0x39),
+		),
 	)
 })
+
+type testEncodable struct{}
+
+var _ gblob.PackedEncodable = testEncodable{}
+
+func (d testEncodable) EncodePacked(encoder gblob.TypedWriter) error {
+	return encoder.WriteUint8(0x39)
+}


### PR DESCRIPTION
## Changes

- Improves the performance of the `TypedWriter` with early bounds checking.
  - Previously this did not seem to have any effect but with the latest Go version it is again required.
- Adds the ability for custom encodable and decodable types
- Restructures the README, splitting performance measurements from user guide
- Restores the benchmark tests and updates the measurements in the README
